### PR TITLE
Remove runtime QuickCheck dependency.

### DIFF
--- a/bv-sized.cabal
+++ b/bv-sized.cabal
@@ -28,7 +28,6 @@ library
                      , parameterized-utils >= 2.0 && < 3
                      , pretty
                      , random >= 1.1 && < 1.2
-                     , QuickCheck >= 2.11
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -38,12 +37,7 @@ test-suite bv-tests
   default-language: Haskell2010
   ghc-options: -Wall
   main-is: Test.hs
-  other-modules:       Data.BitVector.Sized
-  hs-source-dirs: test, src
+  hs-source-dirs: test
   build-depends:       base >= 4.7 && < 5
                      , bv-sized
-                     , lens >= 4 && < 5
-                     , parameterized-utils
-                     , pretty
-                     , random >= 1.1 && < 1.2
-                     , QuickCheck >= 2.11 && < 2.12
+                     , QuickCheck >= 2.11

--- a/src/Data/BitVector/Sized/Internal.hs
+++ b/src/Data/BitVector/Sized/Internal.hs
@@ -28,7 +28,6 @@ import GHC.Generics
 import GHC.TypeLits
 import Numeric
 import System.Random
-import Test.QuickCheck (Arbitrary(..), choose)
 import Text.PrettyPrint.HughesPJClass
 import Text.Printf
 import Unsafe.Coerce (unsafeCoerce)
@@ -400,9 +399,6 @@ instance KnownNat w => Ix (BitVector w) where
 instance KnownNat w => Bounded (BitVector w) where
   minBound = bitVector (0 :: Integer)
   maxBound = bitVector ((-1) :: Integer)
-
-instance KnownNat w => Arbitrary (BitVector w) where
-  arbitrary = choose (minBound, maxBound)
 
 instance KnownNat w => Random (BitVector w) where
   randomR (bvLo, bvHi) gen =

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main where
 
+import GHC.TypeLits
 import Test.QuickCheck
 
 import Data.BitVector.Sized
@@ -11,3 +13,7 @@ main = quickCheck bitVectorTest
 
 bitVectorTest :: BitVector 64 -> Bool
 bitVectorTest bv = bitVector (bvIntegerS bv) == bv
+
+
+instance KnownNat w => Arbitrary (BitVector w) where
+  arbitrary = choose (minBound, maxBound)


### PR DESCRIPTION
Moves the QuickCheck Arbitrary instance to the testing infrastructure
and consolidates testing to the API.

Also removes upper-bound on QuickCheck (current version is 2.14).

Resolves http://fryingpan.dev.galois.com/hydra/build/2518686/nixlog/4