### PR TITLE
Deprecate trunc' in favor of zresize and sresize

### DIFF
--- a/src/Data/BitVector/Sized.hs
+++ b/src/Data/BitVector/Sized.hs
@@ -89,6 +89,8 @@ module Data.BitVector.Sized
   , zext
   , sext
   , trunc, trunc'
+  , zresize
+  , sresize
   , mulWide
     -- * Enum operations
   , succUnsigned, succSigned

--- a/src/Data/BitVector/Sized/Internal.hs
+++ b/src/Data/BitVector/Sized/Internal.hs
@@ -855,6 +855,26 @@ trunc' :: NatRepr w'
        -- ^ Bitvector to truncate
        -> BV w'
 trunc' w' (BV x) = mkBV w' x
+{-# DEPRECATED trunc' "Use zresize instead" #-}
+
+-- | Resizes a bitvector. If @w' > w@, perform a zero extension.
+zresize :: NatRepr w'
+        -- ^ Desired output width
+        -> BV w
+        -- ^ Bitvector to resize
+        -> BV w'
+zresize w' (BV x) = mkBV w' x
+
+-- | Resizes a bitvector. If @w' > w@, perform a signed extension.
+sresize :: 1 <= w
+        => NatRepr w
+        -- ^ Width of input vector
+        -> NatRepr w'
+        -- ^ Desired output width
+        -> BV w
+        -- ^ Bitvector to resize
+        -> BV w'
+sresize w w' bv = mkBV w' (asSigned w bv)
 
 -- | Wide multiply of two bitvectors.
 mulWide :: NatRepr w -> NatRepr w' -> BV w -> BV w' -> BV (w+w')

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -620,6 +620,21 @@ wellFormedTests = testGroup "well-formedness tests"
 
       let BV.BV x = BV.trunc' w' bv
       checkBounds x w'
+  , testProperty "zresize" $ property $ do
+      Some w <- forAll anyWidth
+      Some w' <- forAll anyWidth
+      bv <- BV.mkBV w <$> forAll (unsigned w)
+
+      let BV.BV x = BV.zresize w' bv
+      checkBounds x w'
+  , testProperty "sresize" $ property $ do
+      Some w <- forAll anyPosWidth
+      Just LeqProof <- return $ isPosNat w
+      Some w' <- forAll anyWidth
+      bv <- BV.mkBV w <$> forAll (unsigned w)
+
+      let BV.BV x = BV.sresize w w' bv
+      checkBounds x w'
   , testProperty "mulWide" $ property $ do
       Some w <- forAll anyWidth
       Some w' <- forAll anyWidth


### PR DESCRIPTION
This removes a bit of a wart. `trunc'` was supposed to be a truncation function that did not check the desired output width was smaller than the input. In the case that the output was larger, it performed a zero extension.

I think this is a bad use of the name `trunc'`, so this PR deprecates that function and replaces it with two alternatives: `zresize` and `sresize` depending on whether you want unsigned or signed extension when the desired width is larger than the current width.