### PR TITLE
Unsigned/Signed functions

### DIFF
--- a/src/Data/BitVector/Sized/Signed.hs
+++ b/src/Data/BitVector/Sized/Signed.hs
@@ -23,19 +23,55 @@ instances not provided by 'BV'.
 
 module Data.BitVector.Sized.Signed
   ( SignedBV(..)
-  , mkSignedBV
+    -- * Constructors
+  , mkSignedBV, mkSignedBV'
+  , clamp
+  , zero, one, width
+    -- * Construction from fixed-width data types
+  , bool, int8, int16, int32, int64
+  , bitsBE, bitsLE
+  , bytestringBE, bytestringLE
+  , bytesBE, bytesLE
+    -- * Conversions to primitive types
+  , asBitsBE, asBitsLE
+  , asBytesBE, asBytesLE
+  , asBytestringBE, asBytestringLE
+    -- * Bitwise operations
+    -- | Useful functions not in @Data.Bits@.
+  , ctz, clz
+  , truncBits
+  , signBit
+    -- * Width-changing operations
+  , concat
+  , select
+  , select'
+  , ext
+  , trunc
+  , resize
+  , mulWide
+    -- * Pretty printing
+  , ppHex
+  , ppBin
+  , ppOct
+  , ppDec
   ) where
 
 import           Data.BitVector.Sized (BV, mkBV)
 import qualified Data.BitVector.Sized.Internal as BV
 import           Data.BitVector.Sized.Panic (panic)
-import Data.Parameterized.NatRepr
+import Data.Parameterized.Classes
+import Data.Parameterized.NatRepr (NatRepr, knownNat, widthVal, minSigned, maxSigned)
+import Data.Parameterized.Pair
 
 import Data.Bits (Bits(..), FiniteBits(..))
-import Data.Ix
-import GHC.Generics
-import GHC.TypeLits
-import Numeric.Natural
+import qualified Data.ByteString as BS
+import Data.Int
+import Data.Ix (Ix(inRange, range, index))
+import Data.Word
+import GHC.Generics (Generic)
+import GHC.TypeLits (KnownNat, type (<=), type (+))
+import Numeric.Natural (Natural)
+import Prelude hiding (concat)
 import System.Random
 import System.Random.Stateful
 
@@ -49,9 +85,15 @@ instance (KnownNat w, 1 <= w) => Ord (SignedBV w) where
        | BV.slt knownNat bv1 bv2 -> LT
        | otherwise               -> GT
 
+instance ShowF SignedBV
+
 -- | Convenience wrapper for 'BV.mkBV'.
-mkSignedBV :: NatRepr w -> Integer -> SignedBV w
+mkSignedBV :: 1 <= w => NatRepr w -> Integer -> SignedBV w
 mkSignedBV w x = SignedBV (BV.mkBV w x)
+
+-- | Convenience wrapper for 'BV.mkBVSigned'.
+mkSignedBV' :: 1 <= w => NatRepr w -> Integer -> Maybe (SignedBV w)
+mkSignedBV' w x = SignedBV <$> BV.mkBVSigned w x
 
 liftUnary :: (BV w -> BV w)
           -> SignedBV w
@@ -102,6 +144,15 @@ instance (KnownNat w, 1 <= w) => Num (SignedBV w) where
   fromInteger = SignedBV . mkBV knownNat
   negate      = liftUnary (BV.negate knownNat)
 
+instance (KnownNat w, 1 <= w) => Real (SignedBV w) where
+  toRational (SignedBV bv) = fromInteger (BV.asSigned knownNat bv)
+
+instance (KnownNat w, 1 <= w) => Integral (SignedBV w) where
+  toInteger (SignedBV bv) = BV.asSigned knownNat bv
+  SignedBV bv `quotRem` SignedBV bv' =
+    let (q, r) = BV.squotRem knownNat bv bv'
+    in (SignedBV q, SignedBV r)
+
 instance (KnownNat w, 1 <= w) => Enum (SignedBV w) where
   toEnum = SignedBV . mkBV knownNat . checkInt
     where checkInt i | lo <= toInteger i && toInteger i <= hi = toInteger i
@@ -137,3 +188,268 @@ instance (KnownNat w, 1 <= w) => UniformRange (SignedBV w) where
     SignedBV <$> BV.sUniformRM knownNat (lo, hi) g
 
 instance (KnownNat w, 1 <= w) => Random (SignedBV w)
+
+-- Signed versions of BV operations that aren't captured by the various
+-- instances provided above.
+
+-- | The zero bitvector of any width.
+zero :: 1 <= w => NatRepr w -> SignedBV w
+zero = SignedBV . BV.zero
+
+-- | The bitvector with value 1, of any positive width.
+one :: 1 <= w => NatRepr w -> SignedBV w
+one = SignedBV . BV.one
+
+-- | The bitvector whose value is its own width, of any width.
+width :: 1 <= w => NatRepr w -> SignedBV w
+width = SignedBV . BV.width
+
+-- | @clamp w i@ rounds @i@ to the nearest value between @0@ and @2^w - 1@
+-- (inclusive).
+clamp :: 1 <= w => NatRepr w -> Integer -> SignedBV w
+clamp w x = SignedBV (BV.signedClamp w x)
+
+-- | Construct an 'SignedBV' from a 'Bool'.
+bool :: Bool -> SignedBV 1
+bool = SignedBV . BV.bool
+
+-- | Construct an 'SignedBV' from an 'Int8'.
+int8 :: Int8 -> SignedBV 8
+int8 = SignedBV . BV.int8
+
+-- | Construct an 'SignedBV' from a 'Int16'.
+int16 :: Int16 -> SignedBV 16
+int16 = SignedBV . BV.int16
+
+-- | Construct an 'SignedBV' from a 'Int32'.
+int32 :: Int32 -> SignedBV 32
+int32 = SignedBV . BV.int32
+
+-- | Construct an 'SignedBV' from a 'Int64'.
+int64 :: Int64 -> SignedBV 64
+int64 = SignedBV . BV.int64
+
+-- | Construct an 'SignedBV' from a list of bits, in big endian order (bits with
+-- lower value index in the list are mapped to higher order bits in the output
+-- bitvector). Return the resulting 'SignedBV' along with its width.
+--
+-- >>> case BV.bitsBE [True, False] of p -> (fstPair p, sndPair p)
+-- (2,SignedBV {asBV = BV 2})
+bitsBE :: [Bool] -> Pair NatRepr SignedBV
+bitsBE = viewPair (\w bv -> Pair w (SignedBV bv)) . BV.bitsBE
+
+-- | Construct an 'SignedBV' from a list of bits, in little endian order (bits
+-- with lower value index in the list are mapped to lower order bits in the
+-- output bitvector). Return the resulting 'SignedBV' along with its width.
+--
+-- >>> case BV.bitsLE [True, False] of p -> (fstPair p, sndPair p)
+-- (2,SignedBV {asBV = BV 1})
+bitsLE :: [Bool] -> Pair NatRepr SignedBV
+bitsLE = viewPair (\w bv -> Pair w (SignedBV bv)) . BV.bitsLE
+
+-- | Construct an 'SignedBV' from a big-endian bytestring.
+--
+-- >>> case BV.bytestringBE (BS.pack [0, 1, 1]) of p -> (fstPair p, sndPair p)
+-- (24,SignedBV {asBV = BV 257})
+bytestringBE :: BS.ByteString -> Pair NatRepr SignedBV
+bytestringBE = viewPair (\w bv -> Pair w (SignedBV bv)) . BV.bytestringBE
+
+-- | Construct an 'SignedBV' from a little-endian bytestring.
+--
+-- >>> case BV.bytestringLE (BS.pack [0, 1, 1]) of p -> (fstPair p, sndPair p)
+-- (24,SignedBV {asBV = BV 65792})
+bytestringLE :: BS.ByteString -> Pair NatRepr SignedBV
+bytestringLE = viewPair (\w bv -> Pair w (SignedBV bv)) . BV.bytestringLE
+
+-- | Construct an 'SignedBV' from a list of bytes, in big endian order (bytes
+-- with lower value index in the list are mapped to higher order bytes in the
+-- output bitvector).
+--
+-- >>> case BV.bytesBE [0, 1, 1] of p -> (fstPair p, sndPair p)
+-- (24,SignedBV {asBV = BV 257})
+bytesBE :: [Word8] -> Pair NatRepr SignedBV
+bytesBE = viewPair (\w bv -> Pair w (SignedBV bv)) . BV.bytesBE
+
+-- | Construct an 'SignedBV' from a list of bytes, in little endian order
+-- (bytes with lower value index in the list are mapped to lower order bytes in
+-- the output bitvector).
+--
+-- >>> case BV.bytesLE [0, 1, 1] of p -> (fstPair p, sndPair p)
+-- (24,SignedBV {asBV = BV 65792})
+bytesLE :: [Word8] -> Pair NatRepr SignedBV
+bytesLE = viewPair (\w bv -> Pair w (SignedBV bv)) . BV.bytesLE
+
+-- | Convert a bitvector to a list of bits, in big endian order
+-- (higher order bits in the bitvector are mapped to lower indices in
+-- the output list).
+--
+-- >>> BV.asBitsBE (knownNat @5) (BV.mkSignedBV knownNat 0b1101)
+-- [False,True,True,False,True]
+asBitsBE :: NatRepr w -> SignedBV w -> [Bool]
+asBitsBE w (SignedBV bv) = BV.asBitsBE w bv
+
+-- | Convert a bitvector to a list of bits, in little endian order
+-- (lower order bits in the bitvector are mapped to lower indices in
+-- the output list).
+--
+-- >>> BV.asBitsLE (knownNat @5) (BV.mkSignedBV knownNat 0b1101)
+-- [True,False,True,True,False]
+asBitsLE :: NatRepr w -> SignedBV w -> [Bool]
+asBitsLE w (SignedBV bv) = BV.asBitsLE w bv
+
+-- | Convert a bitvector to a list of bytes, in big endian order
+-- (higher order bytes in the bitvector are mapped to lower indices in
+-- the output list). Return 'Nothing' if the width is not a multiple
+-- of 8.
+--
+-- >>> BV.asBytesBE (knownNat @32) (BV.mkSignedBV knownNat 0xaabbccdd)
+-- Just [170,187,204,221]
+asBytesBE :: NatRepr w -> SignedBV w -> Maybe [Word8]
+asBytesBE w (SignedBV bv) = BV.asBytesBE w bv
+
+-- | Convert a bitvector to a list of bytes, in little endian order
+-- (lower order bytes in the bitvector are mapped to lower indices in
+-- the output list). Return 'Nothing' if the width is not a multiple
+-- of 8.
+--
+-- >>> BV.asBytesLE (knownNat @32) (BV.mkSignedBV knownNat 0xaabbccdd)
+-- Just [221,204,187,170]
+asBytesLE :: NatRepr w -> SignedBV w -> Maybe [Word8]
+asBytesLE w (SignedBV bv) = BV.asBytesLE w bv
+
+-- | 'asBytesBE', but for bytestrings.
+asBytestringBE :: NatRepr w -> SignedBV w -> Maybe BS.ByteString
+asBytestringBE w (SignedBV bv) = BV.asBytestringBE w bv
+
+-- | 'asBytesLE', but for bytestrings.
+asBytestringLE :: NatRepr w -> SignedBV w -> Maybe BS.ByteString
+asBytestringLE w (SignedBV bv) = BV.asBytestringLE w bv
+
+-- | Count trailing zeros in an 'SignedBV'.
+ctz :: NatRepr w -> SignedBV w -> SignedBV w
+ctz w (SignedBV bv) = SignedBV (BV.ctz w bv)
+
+-- | Count leading zeros in an 'SignedBV'.
+clz :: NatRepr w -> SignedBV w -> SignedBV w
+clz w (SignedBV bv) = SignedBV (BV.clz w bv)
+
+-- | Truncate a bitvector to a particular width given at runtime, while keeping
+-- the type-level width constant.
+truncBits :: Natural -> SignedBV w -> SignedBV w
+truncBits b (SignedBV bv) = SignedBV (BV.truncBits b bv)
+
+-- | Get the sign bit as an 'SignedBV'.
+signBit :: 1 <= w => NatRepr w -> SignedBV w -> SignedBV w
+signBit w (SignedBV bv) = SignedBV (BV.signBit w bv)
+
+-- | Concatenate two bitvectors. The first argument gets placed in the
+-- higher order bits.
+--
+-- >>> BV.concat knownNat knownNat (BV.mkSignedBV (knownNat @3) 0b001) (BV.mkSignedBV (knownNat @2) 0b10)
+-- SignedBV {asBV = BV 6}
+-- >>> :type it
+-- it :: BV.SignedBV 5
+concat :: NatRepr w
+       -- ^ Width of higher-order bits
+       -> NatRepr w'
+       -- ^ Width of lower-order bits
+       -> SignedBV w
+       -- ^ Higher-order bits
+       -> SignedBV w'
+       -- ^ Lower-order bits
+       -> SignedBV (w+w')
+concat w w' (SignedBV hi) (SignedBV lo) = SignedBV (BV.concat w w' hi lo)
+
+-- | Slice out a smaller bitvector from a larger one.
+--
+-- >>> BV.select (knownNat @1) (knownNat @4) (BV.mkSignedBV (knownNat @12) 0b110010100110)
+-- SignedBV {asBV = BV 3}
+-- >>> :type it
+-- it :: BV.SignedBV 4
+select :: ix + w' <= w
+       => NatRepr ix
+       -- ^ Index to start selecting from
+       -> NatRepr w'
+       -- ^ Desired output width
+       -> SignedBV w
+       -- ^ Bitvector to select from
+       -> SignedBV w'
+select ix w' (SignedBV bv) = SignedBV (BV.select ix w' bv)
+
+-- | Like 'select', but takes a 'Natural' as the index to start
+-- selecting from. Neither the index nor the output width is checked
+-- to ensure the resulting 'BV' lies entirely within the bounds of the
+-- original bitvector. Any bits "selected" from beyond the bounds of
+-- the input bitvector will be 0.
+--
+-- >>> BV.select' 9 (knownNat @4) (BV.mkSignedBV (knownNat @12) 0b110010100110)
+-- SignedBV {asBV = BV 6}
+-- >>> :type it
+-- it :: BV.SignedBV 4
+select' :: Natural
+        -- ^ Index to start selecting from
+        -> NatRepr w'
+        -- ^ Desired output width
+        -> SignedBV w
+        -- ^ Bitvector to select from
+        -> SignedBV w'
+select' ix w' (SignedBV bv) = SignedBV (BV.select' ix w' bv)
+
+-- | Sign-extend a bitvector to one of strictly greater width.
+--
+-- >>> BV.ext (knownNat @8) (BV.mkSignedBV (knownNat @4) 0b1101)
+-- SignedBV {asBV = BV 253}
+-- >>> :type it
+-- it :: BV.SignedBV 8
+ext :: (1 <= w, w + 1 <= w')
+    => NatRepr w
+    -- ^ Width of input bitvector
+    -> NatRepr w'
+    -- ^ Desired output width
+    -> SignedBV w
+    -- ^ Bitvector to extend
+    -> SignedBV w'
+ext w w' (SignedBV bv) = SignedBV (BV.sext w w' bv)
+
+-- | Truncate a bitvector to one of strictly smaller width.
+trunc :: w' + 1 <= w
+      => NatRepr w'
+      -- ^ Desired output width
+      -> SignedBV w
+      -- ^ Bitvector to truncate
+      -> SignedBV w'
+trunc w' (SignedBV bv) = SignedBV (BV.trunc w' bv)
+
+-- | Resizes a bitvector. If @w' > w@, perform a sign extension.
+resize :: 1 <= w
+       => NatRepr w
+       -- ^ Width of input vector
+       -> NatRepr w'
+       -- ^ Desired output width
+       -> SignedBV w
+       -- ^ Bitvector to resize
+       -> SignedBV w'
+resize w w' (SignedBV bv) = SignedBV (BV.sresize w w' bv)
+
+-- | Wide multiply of two bitvectors.
+mulWide :: NatRepr w -> NatRepr w' -> SignedBV w -> SignedBV w' -> SignedBV (w+w')
+mulWide w w' (SignedBV bv) (SignedBV bv') = SignedBV (BV.mulWide w w' bv bv')
+
+----------------------------------------
+-- Pretty printing
+
+-- | Pretty print in hex
+ppHex :: NatRepr w -> SignedBV w -> String
+ppHex w (SignedBV bv) = BV.ppHex w bv
+
+-- | Pretty print in binary
+ppBin :: NatRepr w -> SignedBV w -> String
+ppBin w (SignedBV bv) = BV.ppBin w bv
+
+-- | Pretty print in octal
+ppOct :: NatRepr w -> SignedBV w -> String
+ppOct w (SignedBV bv) = BV.ppOct w bv
+
+-- | Pretty print in decimal
+ppDec :: NatRepr w -> SignedBV w -> String
+ppDec w (SignedBV bv) = BV.ppDec w bv

--- a/src/Data/BitVector/Sized/Unsigned.hs
+++ b/src/Data/BitVector/Sized/Unsigned.hs
@@ -25,7 +25,7 @@ module Data.BitVector.Sized.Unsigned
     -- * Constructors
   , mkUnsignedBV, mkUnsignedBV'
   , clamp
-  , zero , one , width
+  , zero, one, width
     -- * Construction from fixed-width data types
   , bool, word8, word16, word32, word64
   , bitsBE, bitsLE
@@ -224,7 +224,7 @@ word64 = UnsignedBV . BV.word64
 -- with lower value index in the list are mapped to higher order bits in the
 -- output bitvector). Return the resulting 'UnsignedBV' along with its width.
 --
--- >>> case bitsBE [True, False] of p -> (fstPair p, sndPair p)
+-- >>> case BV.bitsBE [True, False] of p -> (fstPair p, sndPair p)
 -- (2,UnsignedBV {asBV = BV 2})
 bitsBE :: [Bool] -> Pair NatRepr UnsignedBV
 bitsBE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bitsBE
@@ -233,21 +233,21 @@ bitsBE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bitsBE
 -- with lower value index in the list are mapped to lower order bits in the
 -- output bitvector). Return the resulting 'UnsignedBV' along with its width.
 --
--- >>> case bitsLE [True, False] of p -> (fstPair p, sndPair p)
+-- >>> case BV.bitsLE [True, False] of p -> (fstPair p, sndPair p)
 -- (2,UnsignedBV {asBV = BV 1})
 bitsLE :: [Bool] -> Pair NatRepr UnsignedBV
 bitsLE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bitsLE
 
 -- | Construct an 'UnsignedBV' from a big-endian bytestring.
 --
--- >>> case bytestringBE (BS.pack [0, 1, 1]) of p -> (fstPair p, sndPair p)
+-- >>> case BV.bytestringBE (BS.pack [0, 1, 1]) of p -> (fstPair p, sndPair p)
 -- (24,UnsignedBV {asBV = BV 257})
 bytestringBE :: BS.ByteString -> Pair NatRepr UnsignedBV
 bytestringBE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bytestringBE
 
 -- | Construct an 'UnsignedBV' from a little-endian bytestring.
 --
--- >>> case bytestringLE (BS.pack [0, 1, 1]) of p -> (fstPair p, sndPair p)
+-- >>> case BV.bytestringLE (BS.pack [0, 1, 1]) of p -> (fstPair p, sndPair p)
 -- (24,UnsignedBV {asBV = BV 65792})
 bytestringLE :: BS.ByteString -> Pair NatRepr UnsignedBV
 bytestringLE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bytestringLE
@@ -256,7 +256,7 @@ bytestringLE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bytestringLE
 -- with lower value index in the list are mapped to higher order bytes in the
 -- output bitvector).
 --
--- >>> case bytesBE [0, 1, 1] of p -> (fstPair p, sndPair p)
+-- >>> case BV.bytesBE [0, 1, 1] of p -> (fstPair p, sndPair p)
 -- (24,UnsignedBV {asBV = BV 257})
 bytesBE :: [Word8] -> Pair NatRepr UnsignedBV
 bytesBE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bytesBE
@@ -265,7 +265,7 @@ bytesBE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bytesBE
 -- (bytes with lower value index in the list are mapped to lower order bytes in
 -- the output bitvector).
 --
--- >>> case bytesLE [0, 1, 1] of p -> (fstPair p, sndPair p)
+-- >>> case BV.bytesLE [0, 1, 1] of p -> (fstPair p, sndPair p)
 -- (24,UnsignedBV {asBV = BV 65792})
 bytesLE :: [Word8] -> Pair NatRepr UnsignedBV
 bytesLE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bytesLE
@@ -274,7 +274,7 @@ bytesLE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bytesLE
 -- (higher order bits in the bitvector are mapped to lower indices in
 -- the output list).
 --
--- >>> asBitsBE (knownNat @5) (mkUnsignedBV knownNat 0b1101)
+-- >>> BV.asBitsBE (knownNat @5) (BV.mkUnsignedBV knownNat 0b1101)
 -- [False,True,True,False,True]
 asBitsBE :: NatRepr w -> UnsignedBV w -> [Bool]
 asBitsBE w (UnsignedBV bv) = BV.asBitsBE w bv
@@ -283,7 +283,7 @@ asBitsBE w (UnsignedBV bv) = BV.asBitsBE w bv
 -- (lower order bits in the bitvector are mapped to lower indices in
 -- the output list).
 --
--- >>> asBitsLE (knownNat @5) (mkUnsignedBV knownNat 0b1101)
+-- >>> BV.asBitsLE (knownNat @5) (BV.mkUnsignedBV knownNat 0b1101)
 -- [True,False,True,True,False]
 asBitsLE :: NatRepr w -> UnsignedBV w -> [Bool]
 asBitsLE w (UnsignedBV bv) = BV.asBitsLE w bv
@@ -293,7 +293,7 @@ asBitsLE w (UnsignedBV bv) = BV.asBitsLE w bv
 -- the output list). Return 'Nothing' if the width is not a multiple
 -- of 8.
 --
--- >>> asBytesBE (knownNat @32) (mkUnsignedBV knownNat 0xaabbccdd)
+-- >>> BV.asBytesBE (knownNat @32) (BV.mkUnsignedBV knownNat 0xaabbccdd)
 -- Just [170,187,204,221]
 asBytesBE :: NatRepr w -> UnsignedBV w -> Maybe [Word8]
 asBytesBE w (UnsignedBV bv) = BV.asBytesBE w bv
@@ -303,7 +303,7 @@ asBytesBE w (UnsignedBV bv) = BV.asBytesBE w bv
 -- the output list). Return 'Nothing' if the width is not a multiple
 -- of 8.
 --
--- >>> asBytesLE (knownNat @32) (mkUnsignedBV knownNat 0xaabbccdd)
+-- >>> BV.asBytesLE (knownNat @32) (BV.mkUnsignedBV knownNat 0xaabbccdd)
 -- Just [221,204,187,170]
 asBytesLE :: NatRepr w -> UnsignedBV w -> Maybe [Word8]
 asBytesLE w (UnsignedBV bv) = BV.asBytesLE w bv

--- a/src/Data/BitVector/Sized/Unsigned.hs
+++ b/src/Data/BitVector/Sized/Unsigned.hs
@@ -22,19 +22,54 @@ instances not provided by 'BV'.
 
 module Data.BitVector.Sized.Unsigned
   ( UnsignedBV(..)
-  , mkUnsignedBV
+    -- * Constructors
+  , mkUnsignedBV, mkUnsignedBV'
+  , clamp
+  , zero , one , width
+    -- * Construction from fixed-width data types
+  , bool, word8, word16, word32, word64
+  , bitsBE, bitsLE
+  , bytestringBE, bytestringLE
+  , bytesBE, bytesLE
+    -- * Conversions to primitive types
+  , asBitsBE, asBitsLE
+  , asBytesBE, asBytesLE
+  , asBytestringBE, asBytestringLE
+    -- * Bitwise operations
+    -- | Useful functions not in @Data.Bits@.
+  , ctz, clz
+  , truncBits
+  , signBit
+    -- * Width-changing operations
+  , concat
+  , select
+  , select'
+  , ext
+  , trunc
+  , resize
+  , mulWide
+    -- * Pretty printing
+  , ppHex
+  , ppBin
+  , ppOct
+  , ppDec
   ) where
 
 import           Data.BitVector.Sized.Internal (BV(..), mkBV)
 import qualified Data.BitVector.Sized.Internal as BV
 import           Data.BitVector.Sized.Panic (panic)
+import           Data.Parameterized.Classes
 import           Data.Parameterized.NatRepr (NatRepr, knownNat, maxUnsigned, widthVal)
+import           Data.Parameterized.Pair
 
 import Data.Bits (Bits(..), FiniteBits(..))
+import qualified Data.ByteString as BS
 import Data.Ix (Ix(inRange, range, index))
+import Data.Word
 import GHC.Generics (Generic)
-import GHC.TypeLits (KnownNat)
+import GHC.TypeLits (KnownNat, type (<=), type (+))
 import Numeric.Natural (Natural)
+import Prelude hiding (concat)
 import System.Random
 import System.Random.Stateful
 
@@ -42,9 +77,15 @@ import System.Random.Stateful
 newtype UnsignedBV w = UnsignedBV { asBV :: BV w }
   deriving (Generic, Show, Read, Eq, Ord)
 
+instance ShowF UnsignedBV
+
 -- | Convenience wrapper for 'BV.mkBV'.
 mkUnsignedBV :: NatRepr w -> Integer -> UnsignedBV w
 mkUnsignedBV w x = UnsignedBV (BV.mkBV w x)
+
+-- | Convenience wrapper for 'BV.mkBVUnsigned'.
+mkUnsignedBV' :: NatRepr w -> Integer -> Maybe (UnsignedBV w)
+mkUnsignedBV' w x = UnsignedBV <$> BV.mkBVUnsigned w x
 
 liftUnary :: (BV w -> BV w)
           -> UnsignedBV w
@@ -96,6 +137,15 @@ instance KnownNat w => Num (UnsignedBV w) where
   -- in this case, negate just means "additive inverse"
   negate      = liftUnary (BV.negate knownNat)
 
+instance KnownNat w => Real (UnsignedBV w) where
+  toRational (UnsignedBV (BV x)) = fromInteger x
+
+instance KnownNat w => Integral (UnsignedBV w) where
+  toInteger (UnsignedBV (BV x)) = x
+  UnsignedBV bv `quotRem` UnsignedBV bv' =
+    let (q, r) = bv `BV.uquotRem` bv'
+    in (UnsignedBV q, UnsignedBV r)
+
 instance KnownNat w => Enum (UnsignedBV w) where
   toEnum = UnsignedBV . mkBV knownNat . checkInt
     where checkInt i | 0 <= i && toInteger i <= (maxUnsigned (knownNat @w)) = toInteger i
@@ -129,3 +179,263 @@ instance UniformRange (UnsignedBV w) where
     UnsignedBV <$> BV.uUniformRM (lo, hi) g
 
 instance KnownNat w => Random (UnsignedBV w)
+
+-- Unsigned versions of BV operations that aren't captured by the various
+-- instances provided above.
+
+-- | The zero bitvector of any width.
+zero :: NatRepr w -> UnsignedBV w
+zero = UnsignedBV . BV.zero
+
+-- | The bitvector with value 1, of any positive width.
+one :: 1 <= w => NatRepr w -> UnsignedBV w
+one = UnsignedBV . BV.one
+
+-- | The bitvector whose value is its own width, of any width.
+width :: NatRepr w -> UnsignedBV w
+width = UnsignedBV . BV.width
+
+-- | @clamp w i@ rounds @i@ to the nearest value between @0@ and @2^w - 1@
+-- (inclusive).
+clamp :: NatRepr w -> Integer -> UnsignedBV w
+clamp w x = UnsignedBV (BV.unsignedClamp w x)
+
+-- | Construct an 'UnsignedBV' from a 'Bool'.
+bool :: Bool -> UnsignedBV 1
+bool = UnsignedBV . BV.bool
+
+-- | Construct an 'UnsignedBV' from a 'Word8'.
+word8 :: Word8 -> UnsignedBV 8
+word8 = UnsignedBV . BV.word8
+
+-- | Construct an 'UnsignedBV' from a 'Word16'.
+word16 :: Word16 -> UnsignedBV 16
+word16 = UnsignedBV . BV.word16
+
+-- | Construct an 'UnsignedBV' from a 'Word32'.
+word32 :: Word32 -> UnsignedBV 32
+word32 = UnsignedBV . BV.word32
+
+-- | Construct an 'UnsignedBV' from a 'Word64'.
+word64 :: Word64 -> UnsignedBV 64
+word64 = UnsignedBV . BV.word64
+
+-- | Construct an 'UnsignedBV' from a list of bits, in big endian order (bits
+-- with lower value index in the list are mapped to higher order bits in the
+-- output bitvector). Return the resulting 'UnsignedBV' along with its width.
+--
+-- >>> case bitsBE [True, False] of p -> (fstPair p, sndPair p)
+-- (2,UnsignedBV {asBV = BV 2})
+bitsBE :: [Bool] -> Pair NatRepr UnsignedBV
+bitsBE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bitsBE
+
+-- | Construct an 'UnsignedBV' from a list of bits, in little endian order (bits
+-- with lower value index in the list are mapped to lower order bits in the
+-- output bitvector). Return the resulting 'UnsignedBV' along with its width.
+--
+-- >>> case bitsLE [True, False] of p -> (fstPair p, sndPair p)
+-- (2,UnsignedBV {asBV = BV 1})
+bitsLE :: [Bool] -> Pair NatRepr UnsignedBV
+bitsLE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bitsLE
+
+-- | Construct an 'UnsignedBV' from a big-endian bytestring.
+--
+-- >>> case bytestringBE (BS.pack [0, 1, 1]) of p -> (fstPair p, sndPair p)
+-- (24,UnsignedBV {asBV = BV 257})
+bytestringBE :: BS.ByteString -> Pair NatRepr UnsignedBV
+bytestringBE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bytestringBE
+
+-- | Construct an 'UnsignedBV' from a little-endian bytestring.
+--
+-- >>> case bytestringLE (BS.pack [0, 1, 1]) of p -> (fstPair p, sndPair p)
+-- (24,UnsignedBV {asBV = BV 65792})
+bytestringLE :: BS.ByteString -> Pair NatRepr UnsignedBV
+bytestringLE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bytestringLE
+
+-- | Construct an 'UnsignedBV' from a list of bytes, in big endian order (bytes
+-- with lower value index in the list are mapped to higher order bytes in the
+-- output bitvector).
+--
+-- >>> case bytesBE [0, 1, 1] of p -> (fstPair p, sndPair p)
+-- (24,UnsignedBV {asBV = BV 257})
+bytesBE :: [Word8] -> Pair NatRepr UnsignedBV
+bytesBE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bytesBE
+
+-- | Construct an 'UnsignedBV' from a list of bytes, in little endian order
+-- (bytes with lower value index in the list are mapped to lower order bytes in
+-- the output bitvector).
+--
+-- >>> case bytesLE [0, 1, 1] of p -> (fstPair p, sndPair p)
+-- (24,UnsignedBV {asBV = BV 65792})
+bytesLE :: [Word8] -> Pair NatRepr UnsignedBV
+bytesLE = viewPair (\w bv -> Pair w (UnsignedBV bv)) . BV.bytesLE
+
+-- | Convert a bitvector to a list of bits, in big endian order
+-- (higher order bits in the bitvector are mapped to lower indices in
+-- the output list).
+--
+-- >>> asBitsBE (knownNat @5) (mkUnsignedBV knownNat 0b1101)
+-- [False,True,True,False,True]
+asBitsBE :: NatRepr w -> UnsignedBV w -> [Bool]
+asBitsBE w (UnsignedBV bv) = BV.asBitsBE w bv
+
+-- | Convert a bitvector to a list of bits, in little endian order
+-- (lower order bits in the bitvector are mapped to lower indices in
+-- the output list).
+--
+-- >>> asBitsLE (knownNat @5) (mkUnsignedBV knownNat 0b1101)
+-- [True,False,True,True,False]
+asBitsLE :: NatRepr w -> UnsignedBV w -> [Bool]
+asBitsLE w (UnsignedBV bv) = BV.asBitsLE w bv
+
+-- | Convert a bitvector to a list of bytes, in big endian order
+-- (higher order bytes in the bitvector are mapped to lower indices in
+-- the output list). Return 'Nothing' if the width is not a multiple
+-- of 8.
+--
+-- >>> asBytesBE (knownNat @32) (mkUnsignedBV knownNat 0xaabbccdd)
+-- Just [170,187,204,221]
+asBytesBE :: NatRepr w -> UnsignedBV w -> Maybe [Word8]
+asBytesBE w (UnsignedBV bv) = BV.asBytesBE w bv
+
+-- | Convert a bitvector to a list of bytes, in little endian order
+-- (lower order bytes in the bitvector are mapped to lower indices in
+-- the output list). Return 'Nothing' if the width is not a multiple
+-- of 8.
+--
+-- >>> asBytesLE (knownNat @32) (mkUnsignedBV knownNat 0xaabbccdd)
+-- Just [221,204,187,170]
+asBytesLE :: NatRepr w -> UnsignedBV w -> Maybe [Word8]
+asBytesLE w (UnsignedBV bv) = BV.asBytesLE w bv
+
+-- | 'asBytesBE', but for bytestrings.
+asBytestringBE :: NatRepr w -> UnsignedBV w -> Maybe BS.ByteString
+asBytestringBE w (UnsignedBV bv) = BV.asBytestringBE w bv
+
+-- | 'asBytesLE', but for bytestrings.
+asBytestringLE :: NatRepr w -> UnsignedBV w -> Maybe BS.ByteString
+asBytestringLE w (UnsignedBV bv) = BV.asBytestringLE w bv
+
+-- | Count trailing zeros in an 'UnsignedBV'.
+ctz :: NatRepr w -> UnsignedBV w -> UnsignedBV w
+ctz w (UnsignedBV bv) = UnsignedBV (BV.ctz w bv)
+
+-- | Count leading zeros in an 'UnsignedBV'.
+clz :: NatRepr w -> UnsignedBV w -> UnsignedBV w
+clz w (UnsignedBV bv) = UnsignedBV (BV.clz w bv)
+
+-- | Truncate a bitvector to a particular width given at runtime, while keeping
+-- the type-level width constant.
+truncBits :: Natural -> UnsignedBV w -> UnsignedBV w
+truncBits b (UnsignedBV bv) = UnsignedBV (BV.truncBits b bv)
+
+-- | Get the sign bit as an 'UnsignedBV'.
+signBit :: 1 <= w => NatRepr w -> UnsignedBV w -> UnsignedBV w
+signBit w (UnsignedBV bv) = UnsignedBV (BV.signBit w bv)
+
+-- | Concatenate two bitvectors. The first argument gets placed in the
+-- higher order bits.
+--
+-- >>> BV.concat knownNat knownNat (BV.mkUnsignedBV (knownNat @3) 0b001) (BV.mkUnsignedBV (knownNat @2) 0b10)
+-- UnsignedBV {asBV = BV 6}
+-- >>> :type it
+-- it :: BV.UnsignedBV 5
+concat :: NatRepr w
+       -- ^ Width of higher-order bits
+       -> NatRepr w'
+       -- ^ Width of lower-order bits
+       -> UnsignedBV w
+       -- ^ Higher-order bits
+       -> UnsignedBV w'
+       -- ^ Lower-order bits
+       -> UnsignedBV (w+w')
+concat w w' (UnsignedBV hi) (UnsignedBV lo) = UnsignedBV (BV.concat w w' hi lo)
+
+-- | Slice out a smaller bitvector from a larger one.
+--
+-- >>> BV.select (knownNat @1) (knownNat @4) (BV.mkUnsignedBV (knownNat @12) 0b110010100110)
+-- UnsignedBV {asBV = BV 3}
+-- >>> :type it
+-- it :: BV.UnsignedBV 4
+select :: ix + w' <= w
+       => NatRepr ix
+       -- ^ Index to start selecting from
+       -> NatRepr w'
+       -- ^ Desired output width
+       -> UnsignedBV w
+       -- ^ Bitvector to select from
+       -> UnsignedBV w'
+select ix w' (UnsignedBV bv) = UnsignedBV (BV.select ix w' bv)
+
+-- | Like 'select', but takes a 'Natural' as the index to start
+-- selecting from. Neither the index nor the output width is checked
+-- to ensure the resulting 'BV' lies entirely within the bounds of the
+-- original bitvector. Any bits "selected" from beyond the bounds of
+-- the input bitvector will be 0.
+--
+-- >>> BV.select' 9 (knownNat @4) (BV.mkUnsignedBV (knownNat @12) 0b110010100110)
+-- UnsignedBV {asBV = BV 6}
+-- >>> :type it
+-- it :: BV.UnsignedBV 4
+select' :: Natural
+        -- ^ Index to start selecting from
+        -> NatRepr w'
+        -- ^ Desired output width
+        -> UnsignedBV w
+        -- ^ Bitvector to select from
+        -> UnsignedBV w'
+select' ix w' (UnsignedBV bv) = UnsignedBV (BV.select' ix w' bv)
+
+-- | Zero-extend a bitvector to one of strictly greater width.
+--
+-- >>> BV.zext (knownNat @8) (BV.mkUnsignedBV (knownNat @4) 0b1101)
+-- UnsignedBV {asBV = BV 13}
+-- >>> :type it
+-- it :: BV.UnsignedBV 8
+ext :: w + 1 <= w'
+    => NatRepr w'
+    -- ^ Desired output width
+    -> UnsignedBV w
+    -- ^ Bitvector to extend
+    -> UnsignedBV w'
+ext w (UnsignedBV bv) = UnsignedBV (BV.zext w bv)
+
+-- | Truncate a bitvector to one of strictly smaller width.
+trunc :: w' + 1 <= w
+      => NatRepr w'
+      -- ^ Desired output width
+      -> UnsignedBV w
+      -- ^ Bitvector to truncate
+      -> UnsignedBV w'
+trunc w' (UnsignedBV bv) = UnsignedBV (BV.trunc w' bv)
+
+-- | Resizes a bitvector. If @w' > w@, perform a zero extension.
+resize :: NatRepr w'
+       -- ^ Desired output width
+       -> UnsignedBV w
+       -- ^ Bitvector to resize
+       -> UnsignedBV w'
+resize w' (UnsignedBV bv) = UnsignedBV (BV.zresize w' bv)
+
+-- | Wide multiply of two bitvectors.
+mulWide :: NatRepr w -> NatRepr w' -> UnsignedBV w -> UnsignedBV w' -> UnsignedBV (w+w')
+mulWide w w' (UnsignedBV bv) (UnsignedBV bv') = UnsignedBV (BV.mulWide w w' bv bv')
+
+----------------------------------------
+-- Pretty printing
+
+-- | Pretty print in hex
+ppHex :: NatRepr w -> UnsignedBV w -> String
+ppHex w (UnsignedBV bv) = BV.ppHex w bv
+
+-- | Pretty print in binary
+ppBin :: NatRepr w -> UnsignedBV w -> String
+ppBin w (UnsignedBV bv) = BV.ppBin w bv
+
+-- | Pretty print in octal
+ppOct :: NatRepr w -> UnsignedBV w -> String
+ppOct w (UnsignedBV bv) = BV.ppOct w bv
+
+-- | Pretty print in decimal
+ppDec :: NatRepr w -> UnsignedBV w -> String
+ppDec w (UnsignedBV bv) = BV.ppDec w bv

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-warnings-deprecations #-}
 
 module Main where
 
@@ -18,8 +19,8 @@ import Test.Tasty.Hedgehog
 
 -- Modules under test
 import qualified Data.BitVector.Sized as BV
-import qualified Data.BitVector.Sized.Unsigned as BV
-import qualified Data.BitVector.Sized.Signed as BV
+import qualified Data.BitVector.Sized.Unsigned as UBV
+import qualified Data.BitVector.Sized.Signed as SBV
 
 -- Auxiliary modules
 import Control.Monad.Random
@@ -655,7 +656,7 @@ wellFormedTests = testGroup "well-formedness tests"
 
 testRandomR :: (Ord (f w), Random (f w), Show (f w), Show a)
             => NatRepr w
-            -> (forall w' . NatRepr w' -> a -> f w')
+            -> (NatRepr w -> a -> f w)
             -> (NatRepr w -> Gen a)
             -> Property
 testRandomR w mk gen = property $ do
@@ -677,15 +678,15 @@ testRandomR w mk gen = property $ do
 randomTests :: TestTree
 randomTests = testGroup "tests for random generation"
   [ testProperty "random unsigned well-formed" $ property $ do
-      BV.UnsignedBV (BV.BV x) :: BV.UnsignedBV 32 <- liftIO $ getRandom
+      UBV.UnsignedBV (BV.BV x) :: UBV.UnsignedBV 32 <- liftIO $ getRandom
       checkBounds x (knownNat @32)
   , testProperty "random signed well-formed" $ property $ do
-      BV.SignedBV (BV.BV x) :: BV.SignedBV 32 <- liftIO $ getRandom
+      SBV.SignedBV (BV.BV x) :: SBV.SignedBV 32 <- liftIO $ getRandom
       checkBounds x (knownNat @32)
   , testProperty "randomR unsigned well-formed and in bounds" $
-    testRandomR (knownNat @32) BV.mkUnsignedBV unsigned
+    testRandomR (knownNat @32) UBV.mkUnsignedBV unsigned
   , testProperty "randomR signed well-formed and in bounds" $
-    testRandomR (knownNat @32) BV.mkSignedBV unsigned
+    testRandomR (knownNat @32) SBV.mkSignedBV signed
   ]
 
 tests :: TestTree


### PR DESCRIPTION
This adds a number of functions to the `Signed` and `Unsigned` modules. Still need to implement `Generic` for `Signed`, as the GADT constraint ruins the `deriving` mechanism.

This is technically a breaking change, so the minor version should be bumped.