### PR TITLE
Allow building with GHC 9.2

### DIFF
--- a/bv-sized.cabal
+++ b/bv-sized.cabal
@@ -28,7 +28,7 @@ library
                        Data.BitVector.Sized.Panic
   build-depends:       base >= 4.10 && <5,
                        bitwise >= 1.0.0 && < 1.1,
-                       bytestring >= 0.10 && < 0.11,
+                       bytestring >= 0.10 && < 0.12,
                        deepseq >= 1.4.0 && < 1.5.0,
                        panic >= 0.4.0 && < 0.5,
                        parameterized-utils >= 2.0.2 && < 2.2,

--- a/src/Data/BitVector/Sized/Signed.hs
+++ b/src/Data/BitVector/Sized/Signed.hs
@@ -34,8 +34,8 @@ import Data.Parameterized.NatRepr
 import Data.Bits (Bits(..), FiniteBits(..))
 import Data.Ix
 import GHC.Generics
-import GHC.TypeLits
-import Numeric.Natural
+import GHC.TypeLits (KnownNat)
+import Numeric.Natural (Natural)
 import System.Random
 import System.Random.Stateful
 


### PR DESCRIPTION
This PR contains two commits which allow `bv-sized` to build without warnings on GHC 9.2.