### PR TITLE
Adds Lift, NFData and Hashable instances for SignedBV and UnsignedBV

### DIFF
--- a/src/Data/BitVector/Sized/Signed.hs
+++ b/src/Data/BitVector/Sized/Signed.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiWayIf #-}
@@ -26,22 +28,25 @@ module Data.BitVector.Sized.Signed
   , mkSignedBV
   ) where
 
+import Control.DeepSeq (NFData)
 import           Data.BitVector.Sized (BV, mkBV)
 import qualified Data.BitVector.Sized.Internal as BV
 import           Data.BitVector.Sized.Panic (panic)
+import Data.Parameterized.Classes (Hashable(..))
 import Data.Parameterized.NatRepr
 
 import Data.Bits (Bits(..), FiniteBits(..))
 import Data.Ix
 import GHC.Generics
 import GHC.TypeLits (KnownNat)
+import Language.Haskell.TH.Lift (Lift)
 import Numeric.Natural (Natural)
 import System.Random
 import System.Random.Stateful
 
 -- | Signed bit vector.
 newtype SignedBV w = SignedBV { asBV :: BV w }
-  deriving (Generic, Show, Read, Eq)
+  deriving (Generic, Show, Read, Eq, Lift, NFData)
 
 instance (KnownNat w, 1 <= w) => Ord (SignedBV w) where
   SignedBV bv1 `compare` SignedBV bv2 =
@@ -137,3 +142,6 @@ instance (KnownNat w, 1 <= w) => UniformRange (SignedBV w) where
     SignedBV <$> BV.sUniformRM knownNat (lo, hi) g
 
 instance (KnownNat w, 1 <= w) => Random (SignedBV w)
+
+instance Hashable (SignedBV w) where
+  hashWithSalt salt (SignedBV b) = hashWithSalt salt b

--- a/src/Data/BitVector/Sized/Unsigned.hs
+++ b/src/Data/BitVector/Sized/Unsigned.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -25,22 +27,25 @@ module Data.BitVector.Sized.Unsigned
   , mkUnsignedBV
   ) where
 
+import Control.DeepSeq (NFData)
 import           Data.BitVector.Sized.Internal (BV(..), mkBV)
 import qualified Data.BitVector.Sized.Internal as BV
 import           Data.BitVector.Sized.Panic (panic)
+import           Data.Parameterized.Classes (Hashable(..))
 import           Data.Parameterized.NatRepr (NatRepr, knownNat, maxUnsigned, widthVal)
 
 import Data.Bits (Bits(..), FiniteBits(..))
 import Data.Ix (Ix(inRange, range, index))
 import GHC.Generics (Generic)
 import GHC.TypeLits (KnownNat)
+import Language.Haskell.TH.Lift (Lift)
 import Numeric.Natural (Natural)
 import System.Random
 import System.Random.Stateful
 
 -- | Signed bit vector.
 newtype UnsignedBV w = UnsignedBV { asBV :: BV w }
-  deriving (Generic, Show, Read, Eq, Ord)
+  deriving (Generic, Show, Read, Eq, Ord, Lift, NFData)
 
 -- | Convenience wrapper for 'BV.mkBV'.
 mkUnsignedBV :: NatRepr w -> Integer -> UnsignedBV w
@@ -129,3 +134,6 @@ instance UniformRange (UnsignedBV w) where
     UnsignedBV <$> BV.uUniformRM (lo, hi) g
 
 instance KnownNat w => Random (UnsignedBV w)
+
+instance Hashable (UnsignedBV w) where
+  hashWithSalt salt (UnsignedBV b) = hashWithSalt salt b


### PR DESCRIPTION
The `Lift`, `NFData` and `Hashable` instances are implemented for `BV`, but not for `SignedBV` or `UnsignedBV`. This pull request implements the missing functionalities.