### PR TITLE
Support building with GHC 9.4

### DIFF
--- a/bv-sized.cabal
+++ b/bv-sized.cabal
@@ -49,6 +49,6 @@ test-suite bv-sized-tests
                        MonadRandom >= 0.5.3 && < 0.6,
                        parameterized-utils,
                        tasty >= 1.2.3 && < 1.5,
-                       tasty-hedgehog >= 1.2 && < 1.3
+                       tasty-hedgehog >= 1.2 && < 1.5
   default-language:    Haskell2010
   ghc-options:         -Wall -Wcompat

--- a/src/Data/BitVector/Sized/Signed.hs
+++ b/src/Data/BitVector/Sized/Signed.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-|
 Module      : Data.BitVector.Sized.Signed


### PR DESCRIPTION
This contains two small tweaks needed to build `bv-sized` with GHC 9.4:

* GHC 9.4 is pickier about requiring `UndecidableInstances` (see [here](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.4?version_id=24540b698481cf2b0bd11029b58eaddc0fbfbb31#stricter-undecidableinstances-checking)), and as a result, `Data.BitVector.Sized.Signed` fails to compile without it.
* The upper version bounds on `tasty-hedgehog` have been raised, as GHC 9.4 requires a more recent version than what was allowed.