### PR TITLE
Allow building with `bytestring-0.12.*`, `deepseq-1.5.*`, and `tasty-1.5.*`

### DIFF
--- a/bv-sized.cabal
+++ b/bv-sized.cabal
@@ -28,8 +28,8 @@ library
                        Data.BitVector.Sized.Panic
   build-depends:       base >= 4.11 && <5,
                        bitwise >= 1.0.0 && < 1.1,
-                       bytestring >= 0.10 && < 0.12,
-                       deepseq >= 1.4.0 && < 1.5.0,
+                       bytestring >= 0.10 && < 0.13,
+                       deepseq >= 1.4.0 && < 1.6,
                        panic >= 0.4.0 && < 0.5,
                        parameterized-utils >= 2.0.2 && < 2.2,
                        random >= 1.2.0 && < 1.3,
@@ -48,7 +48,7 @@ test-suite bv-sized-tests
                        hedgehog,
                        MonadRandom >= 0.5.3 && < 0.7,
                        parameterized-utils,
-                       tasty >= 1.2.3 && < 1.5,
+                       tasty >= 1.2.3 && < 1.6,
                        tasty-hedgehog >= 1.2 && < 1.5
   default-language:    Haskell2010
   ghc-options:         -Wall -Wcompat


### PR DESCRIPTION
These are needed to make `bv-sized` cleanly build with GHC 9.8.